### PR TITLE
Fix slider seeking by adding a player seekable connection.

### DIFF
--- a/src/gui/playerwidget.cpp
+++ b/src/gui/playerwidget.cpp
@@ -124,7 +124,8 @@ void PlayerWidget::onBtnOpen_Clicked()
 	updateTitle();
 
 	m_ui->btn_PlayPause->setEnabled(true);
-	m_ui->slider_Duration->setEnabled(m_player->isSeekable());
+	// m_ui->slider_Duration->setEnabled(m_player->isSeekable());
+        connect(m_player.get(), SIGNAL(seekableChanged(bool)), this, SLOT(onPlayerSeekableChanged(bool)));
 	m_ui->slider_Duration->setMaximum(m_player->duration());
 	m_ui->slider_Duration->setValue(m_player->position());
 
@@ -182,6 +183,11 @@ void PlayerWidget::onPlayerPositionChanged(qint64 pos)
 	m_ui->slider_Duration->blockSignals(true);
 	m_ui->slider_Duration->setValue(pos);
 	m_ui->slider_Duration->blockSignals(false);
+}
+
+void PlayerWidget::onPlayerSeekableChanged(bool state)
+{
+        m_ui->slider_Duration->setEnabled(state);
 }
 
 void PlayerWidget::onPlayerMetadataChanged(Player::MetaData key, const QVariant &value)

--- a/src/gui/playerwidget.h
+++ b/src/gui/playerwidget.h
@@ -48,6 +48,7 @@ private Q_SLOTS:
 	void onPlayerStateChanged(Player::State state);
 	void onPlayerDurationChanged(qint64 duration);
 	void onPlayerPositionChanged(qint64 pos);
+        void onPlayerSeekableChanged(bool state);
 	void onPlayerMetadataChanged(Player::MetaData key, const QVariant &value);
 
 private:


### PR DESCRIPTION
Under Linux, I couldn't seek using the slider, which, understandably, was very annoying when sync'ing lyrics :) After a search, I found out that the QMediaPlayer works asynchronously and it enables seeking a bit later after its creation, also emitting a signal when that property changes. I modified the code to enable seeking on this signal, instead of using the original (too early, at least in my case) query.